### PR TITLE
refactor(captcha): 更新图片验证码提供者中的文件类型枚举引用

### DIFF
--- a/athena-security-project/athena-security-captcha/src/main/java/com/gls/athena/security/captcha/provider/impl/ImageCaptchaProvider.java
+++ b/athena-security-project/athena-security-captcha/src/main/java/com/gls/athena/security/captcha/provider/impl/ImageCaptchaProvider.java
@@ -3,13 +3,13 @@ package com.gls.athena.security.captcha.provider.impl;
 import cn.hutool.captcha.CaptchaUtil;
 import cn.hutool.captcha.LineCaptcha;
 import cn.hutool.core.date.DateUtil;
+import com.gls.athena.common.core.constant.FileTypeEnums;
 import com.gls.athena.security.captcha.config.CaptchaEnums;
 import com.gls.athena.security.captcha.config.CaptchaProperties;
 import com.gls.athena.security.captcha.config.ImageCaptchaProperties;
 import com.gls.athena.security.captcha.domain.ImageCaptcha;
 import com.gls.athena.security.captcha.filter.CaptchaException;
 import com.gls.athena.security.captcha.repository.CaptchaRepository;
-import com.gls.athena.starter.web.enums.FileEnums;
 import com.gls.athena.starter.web.util.WebUtil;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -70,7 +70,7 @@ public class ImageCaptchaProvider extends BaseCaptchaProvider<ImageCaptcha> {
      */
     @Override
     protected void doSendCaptcha(String key, ImageCaptcha captcha, HttpServletResponse response) {
-        try (OutputStream out = WebUtil.createOutputStream(response, key, FileEnums.PNG)) {
+        try (OutputStream out = WebUtil.createOutputStream(response, key, FileTypeEnums.PNG)) {
             // 将验证码图片以PNG格式写入输出流
             ImageIO.write(captcha.getImage(), "PNG", out);
         } catch (Exception e) {


### PR DESCRIPTION
- 将 ImageCaptchaProvider 中使用的 FileEnums.PNG 替换为 FileTypeEnums.PNG
- 调整了相关的导入包，移除了旧的 com.gls.athena.starter.web.enums.FileEnums -保持验证码图片输出逻辑不变，仅更新了依赖的枚举类型